### PR TITLE
Rewrite simple logger to avoid static init order fiasco

### DIFF
--- a/lib/simpleLogger/CMakeLists.txt
+++ b/lib/simpleLogger/CMakeLists.txt
@@ -4,15 +4,22 @@ project(simpleLogger CXX)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-add_library(simpleLogger INTERFACE)
+add_library(simpleLogger)
 add_library(simpleLogger::simpleLogger ALIAS simpleLogger)
 
 if (DEFINED SIMPLE_LOGGER_LEVEL)
-  target_compile_definitions(simpleLogger INTERFACE SIMPLE_LOGGER_LEVEL=${SIMPLE_LOGGER_LEVEL})
+  target_compile_definitions(simpleLogger PRIVATE SIMPLE_LOGGER_LEVEL=${SIMPLE_LOGGER_LEVEL})
 endif()
 
-target_include_directories(simpleLogger INTERFACE
-  include
-  )
+if (DEFINED SIMPLE_LOGGER_OSTREAM)
+  target_compile_definitions(simpleLogger PRIVATE SIMPLE_LOGGER_OSTREAM=${SIMPLE_LOGGER_OSTREAM})
+endif()
+
+target_include_directories(simpleLogger
+  PUBLIC include
+  PRIVATE include/simpleLogger
+)
+
+add_subdirectory(src)
 
 

--- a/lib/simpleLogger/include/simpleLogger/SimpleLogger.h
+++ b/lib/simpleLogger/include/simpleLogger/SimpleLogger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 
 class SimpleLogger
 {
@@ -42,11 +43,8 @@ public:
 		SimpleLogger::Level level_{SimpleLogger::Level::warning};
 	};
 
-	SimpleLogger(std::ostream *stream, Level level)
-	    : critical(*this, Level::critical), error(*this, Level::error), warning(*this, Level::warning),
-	      info(*this, Level::info), debug(*this, Level::debug), stream_{stream}, level_{level}
-	{
-	}
+	// Singleton accessor
+	static SimpleLogger &get();
 
 	template <typename T>
 	SimpleLogger &operator<<(const T &x)
@@ -69,13 +67,17 @@ public:
 	OstreamWrapper debug;
 
 private:
+	SimpleLogger(std::ostream *stream, Level level)
+	    : critical(*this, Level::critical), error(*this, Level::error), warning(*this, Level::warning),
+	      info(*this, Level::info), debug(*this, Level::debug), stream_{stream}, level_{level}
+	{
+	}
+
+
 	std::ostream *stream_{nullptr};
 	Level level_{Level::warning};
 };
 
-#ifndef SIMPLE_LOGGER_LEVEL
-#define SIMPLE_LOGGER_LEVEL info
-#endif
-
-#define SETUP_SIMPLE_LOGGER(simpleLoggerName)                                                                          \
-	static SimpleLogger simpleLoggerName(&std::cout, SimpleLogger::Level::SIMPLE_LOGGER_LEVEL)
+#define simpleLogger SimpleLogger::get()
+// #define SETUP_SIMPLE_LOGGER(simpleLoggerName)                                                                          \
+// 	static SimpleLogger simpleLoggerName(&std::cout, SimpleLogger::Level::SIMPLE_LOGGER_LEVEL)

--- a/lib/simpleLogger/src/CMakeLists.txt
+++ b/lib/simpleLogger/src/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.21)
+
+
+target_sources(simpleLogger PRIVATE
+  SimpleLogger.cpp
+)
+
+

--- a/lib/simpleLogger/src/SimpleLogger.cpp
+++ b/lib/simpleLogger/src/SimpleLogger.cpp
@@ -1,0 +1,22 @@
+#include "SimpleLogger.h"
+
+#ifndef SIMPLE_LOGGER_LEVEL
+#define SIMPLE_LOGGER_LEVEL info
+#endif
+
+#ifndef SIMPLE_LOGGER_OSTREAM
+#define SIMPLE_LOGGER_OSTREAM std::cout
+#endif
+
+static std::unique_ptr<SimpleLogger> s_simpleLogger;
+
+
+SimpleLogger &SimpleLogger::get()
+{
+	if (!s_simpleLogger)
+	{
+		s_simpleLogger =
+		    std::unique_ptr<SimpleLogger>(new SimpleLogger(&SIMPLE_LOGGER_OSTREAM, Level::SIMPLE_LOGGER_LEVEL));
+	}
+	return *s_simpleLogger;
+}

--- a/src/SockEPFactory.cpp
+++ b/src/SockEPFactory.cpp
@@ -14,7 +14,6 @@
 #include "server/UnixStreamServerSockEP.h"
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
 
 using namespace sockep;
 

--- a/src/client/ClientSockEP.cpp
+++ b/src/client/ClientSockEP.cpp
@@ -5,7 +5,6 @@
 #include <unistd.h>
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
 
 using namespace sockep;
 

--- a/src/client/TcpClientSockEP.cpp
+++ b/src/client/TcpClientSockEP.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
 
 using namespace sockep;
 

--- a/src/client/UdpClientSockEP.cpp
+++ b/src/client/UdpClientSockEP.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
 
 using namespace sockep;
 

--- a/src/client/UnixDgramClientSockEP.cpp
+++ b/src/client/UnixDgramClientSockEP.cpp
@@ -4,7 +4,6 @@
 #include <sys/poll.h>
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
 
 using namespace sockep;
 

--- a/src/client/UnixStreamClientSockEP.cpp
+++ b/src/client/UnixStreamClientSockEP.cpp
@@ -3,7 +3,6 @@
 #include <iostream>
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
 
 using namespace sockep;
 

--- a/src/server/ServerSockEP.cpp
+++ b/src/server/ServerSockEP.cpp
@@ -7,7 +7,6 @@
 #include <unistd.h>
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
 
 using namespace sockep;
 

--- a/src/server/TcpServerSockEP.cpp
+++ b/src/server/TcpServerSockEP.cpp
@@ -5,7 +5,6 @@
 #include <sys/socket.h>
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
 
 using namespace sockep;
 

--- a/src/server/UdpServerSockEP.cpp
+++ b/src/server/UdpServerSockEP.cpp
@@ -5,7 +5,6 @@
 #include <sys/socket.h>
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
 
 using namespace sockep;
 

--- a/src/server/UnixDgramServerSockEP.cpp
+++ b/src/server/UnixDgramServerSockEP.cpp
@@ -5,7 +5,6 @@
 #include <sys/socket.h>
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
 
 using namespace sockep;
 

--- a/src/server/UnixStreamServerSockEP.cpp
+++ b/src/server/UnixStreamServerSockEP.cpp
@@ -5,7 +5,7 @@
 #include <sys/socket.h>
 
 #include "simpleLogger/SimpleLogger.h"
-SETUP_SIMPLE_LOGGER(simpleLogger);
+
 using namespace sockep;
 
 UnixStreamServerSockEP::UnixStreamServerSockEP(std::string bindPath,


### PR DESCRIPTION
Rewrite simple logger to use a static singleton in its cpp file to avoid the static initialization order fiasco